### PR TITLE
Allow opening files outside of workspace folder

### DIFF
--- a/src/H5WebViewer.ts
+++ b/src/H5WebViewer.ts
@@ -34,7 +34,7 @@ export default class H5WebViewer
     const { webview } = webviewPanel;
 
     // Allow opening files outside of workspace
-    // https://github.com/ucodkr/vscode-tiff/blob/master/src/tiffPreview.ts#L27-L30
+    // https://github.com/ucodkr/vscode-tiff/blob/9a4f976584fcba24e9f25680fcdb47fc8f97493f/src/tiffPreview.ts#L27-L30
     const extensionRoot = Uri.file(this.context.extensionPath);
     const resourceRoot = document.uri.with({
       path: document.uri.path.replace(/\/[^/]+?\.\w+$/, '/'),

--- a/src/H5WebViewer.ts
+++ b/src/H5WebViewer.ts
@@ -32,7 +32,19 @@ export default class H5WebViewer
     webviewPanel: WebviewPanel
   ): Promise<void> {
     const { webview } = webviewPanel;
-    webview.options = { enableScripts: true };
+
+    // Allow opening files outside of workspace
+    // https://github.com/ucodkr/vscode-tiff/blob/master/src/tiffPreview.ts#L27-L30
+    const extensionRoot = Uri.file(this.context.extensionPath);
+    const resourceRoot = document.uri.with({
+      path: document.uri.path.replace(/\/[^/]+?\.\w+$/, '/'),
+    });
+
+    webview.options = {
+      enableScripts: true,
+      localResourceRoots: [resourceRoot, extensionRoot],
+    };
+
     webview.html = await this.getHtmlForWebview(webview);
 
     webview.onDidReceiveMessage((evt) => {


### PR DESCRIPTION
Fix #2 - the issue came from trying to open HDF5 files outside of the current worspace. The internal HTTP request was failing with a 401 Unauthorised error.

The folder of the file being opened has to be added to the webview's configuration.