### PR TITLE
Remove obsolete file read

### DIFF
--- a/src/H5WebViewer.ts
+++ b/src/H5WebViewer.ts
@@ -1,34 +1,24 @@
 import {
-  CancellationToken,
-  CustomDocumentOpenContext,
+  CustomDocument,
   CustomReadonlyEditorProvider,
   ExtensionContext,
   Uri,
   Webview,
   WebviewPanel,
-  workspace,
 } from 'vscode';
-import HDF5Document from './HDF5Document';
 import { join, basename } from 'path';
 
 export default class H5WebViewer
-  implements CustomReadonlyEditorProvider<HDF5Document>
+  implements CustomReadonlyEditorProvider<CustomDocument>
 {
   public constructor(private readonly context: ExtensionContext) {}
 
-  public async openCustomDocument(
-    uri: Uri,
-    openContext: CustomDocumentOpenContext
-  ): Promise<HDF5Document> {
-    const { backupId } = openContext;
-    const fileUri = typeof backupId === 'string' ? Uri.parse(backupId) : uri;
-
-    const buffer = await workspace.fs.readFile(fileUri);
-    return new HDF5Document(uri, buffer);
+  public async openCustomDocument(uri: Uri): Promise<CustomDocument> {
+    return { uri, dispose: () => {} };
   }
 
   public async resolveCustomEditor(
-    document: HDF5Document,
+    document: CustomDocument,
     webviewPanel: WebviewPanel
   ): Promise<void> {
     const { webview } = webviewPanel;

--- a/src/HDF5Document.ts
+++ b/src/HDF5Document.ts
@@ -1,6 +1,0 @@
-import { CustomDocument, Uri } from 'vscode';
-
-export default class HDF5Document implements CustomDocument {
-  constructor(public uri: Uri, public buffer: ArrayBuffer) {}
-  dispose(): void {}
-}


### PR DESCRIPTION
Left over from my initial attempt of reading the file from the extension code and passing the buffer to the webview via  `postMessage`. This clean-up speeds up the extension a bit :tada: 