### PR TITLE
Upgrade Node and H5Web + add CI workflow

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -1,0 +1,74 @@
+name: Lint & Build
+
+on:
+  pull_request: # for PRs from forks
+  push: # to start jobs asap when pushing a branch to open a PR
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - name: Checkout 🏷️
+        uses: actions/checkout@v3
+
+      - name: Set up Node 🕹️
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+
+      - name: Install pnpm ⚙️
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7.x
+
+      - name: Restore cache 📌
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/setup-pnpm/node_modules/.bin/store
+          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - name: Install dependencies ⚙️
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint 🤓
+        run: pnpm prettier
+
+  build:
+    runs-on: ubuntu-latest
+    # Skip `pull_request` runs on local PRs for which `push` runs are already triggered
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - name: Checkout 🏷️
+        uses: actions/checkout@v3
+
+      - name: Set up Node 🕹️
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
+
+      - name: Install pnpm ⚙️
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7.x
+
+      - name: Restore cache 📌
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/setup-pnpm/node_modules/.bin/store
+          key: cache-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-
+
+      - name: Install dependencies ⚙️
+        run: pnpm install --frozen-lockfile
+
+      - name: Build 👓
+        run: pnpm build

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "Visualization"
   ],
   "engines": {
-    "node": "16.x",
+    "node": "18.x",
     "pnpm": "7.x",
     "vscode": ">=1.46.0"
   },
@@ -66,8 +66,8 @@
     "pub": "pnpx vsce publish --no-dependencies"
   },
   "dependencies": {
-    "@h5web/app": "7.0.0",
-    "@h5web/h5wasm": "7.0.0",
+    "@h5web/app": "7.1.0",
+    "@h5web/h5wasm": "7.1.0",
     "@react-hookz/web": "15.0.1",
     "axios": "0.27.2",
     "normalize.css": "8.0.1",
@@ -77,13 +77,13 @@
     "suspend-react": "0.0.8"
   },
   "devDependencies": {
-    "@types/node": "16.11.7",
-    "@types/react": "17.0.33",
-    "@types/react-dom": "17.0.10",
-    "@types/vscode": "1.46.0",
+    "@types/node": "^18.15.11",
+    "@types/react": "^17.0.58",
+    "@types/react-dom": "^17.0.19",
+    "@types/vscode": "~1.46.0",
     "@vitejs/plugin-react": "1.3.2",
     "esbuild": "0.14.49",
-    "prettier": "2.7.1",
+    "prettier": "2.8.7",
     "typescript": "4.7.3",
     "vite": "2.9.13"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,18 +1,18 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@h5web/app': 7.0.0
-  '@h5web/h5wasm': 7.0.0
+  '@h5web/app': 7.1.0
+  '@h5web/h5wasm': 7.1.0
   '@react-hookz/web': 15.0.1
-  '@types/node': 16.11.7
-  '@types/react': 17.0.33
-  '@types/react-dom': 17.0.10
-  '@types/vscode': 1.46.0
+  '@types/node': ^18.15.11
+  '@types/react': ^17.0.58
+  '@types/react-dom': ^17.0.19
+  '@types/vscode': ~1.46.0
   '@vitejs/plugin-react': 1.3.2
   axios: 0.27.2
   esbuild: 0.14.49
   normalize.css: 8.0.1
-  prettier: 2.7.1
+  prettier: 2.8.7
   react: 17.0.2
   react-dom: 17.0.2
   react-error-boundary: 3.1.4
@@ -21,8 +21,8 @@ specifiers:
   vite: 2.9.13
 
 dependencies:
-  '@h5web/app': 7.0.0_sfoxds7t5ydpegc3knd667wn6m
-  '@h5web/h5wasm': 7.0.0_v6np5sctutpiswsic6secylrte
+  '@h5web/app': 7.1.0_sfoxds7t5ydpegc3knd667wn6m
+  '@h5web/h5wasm': 7.1.0_us572w4v6dabsn6wrxmocc5w5u
   '@react-hookz/web': 15.0.1_sfoxds7t5ydpegc3knd667wn6m
   axios: 0.27.2
   normalize.css: 8.0.1
@@ -32,13 +32,13 @@ dependencies:
   suspend-react: 0.0.8_react@17.0.2
 
 devDependencies:
-  '@types/node': 16.11.7
-  '@types/react': 17.0.33
-  '@types/react-dom': 17.0.10
+  '@types/node': 18.15.11
+  '@types/react': 17.0.58
+  '@types/react-dom': 17.0.19
   '@types/vscode': 1.46.0
   '@vitejs/plugin-react': 1.3.2
   esbuild: 0.14.49
-  prettier: 2.7.1
+  prettier: 2.8.7
   typescript: 4.7.3
   vite: 2.9.13
 
@@ -312,64 +312,64 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@h5web/app/7.0.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-2D3JNj8t8ToMBJ0Qj8ck1LxolVcLVE6kAHDmPjakAC3Cs7iQ2QC6fg7G1uu3zAVO7eVNJbPkcUBip6pXJkXqEw==}
+  /@h5web/app/7.1.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-pbwAc4OuhcKSqP8LPl+nA3OPEoHsPjLRd1pyUEPI0j+xfjh+NjXIZPGhY/RTQWuViPcbWnibEVxdTUTApEY6qQ==}
     peerDependencies:
       react: '>=16'
       react-dom: '>=16'
     dependencies:
-      '@h5web/lib': 7.0.0_ec7apzrlzucnkzulcswl7v7zfu
-      '@react-hookz/web': 22.0.0_sfoxds7t5ydpegc3knd667wn6m
+      '@h5web/lib': 7.1.0_ec7apzrlzucnkzulcswl7v7zfu
+      '@react-hookz/web': 23.0.0_sfoxds7t5ydpegc3knd667wn6m
       '@react-three/fiber': 7.0.26_weaphyuqmcotibvxgot4zxypyi
-      axios: 1.2.2
+      axios: 1.3.4
       d3-format: 3.1.0
       lodash: 4.17.21
       ndarray: 1.0.19
       ndarray-ops: 1.2.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-error-boundary: 3.1.4_react@17.0.2
-      react-icons: 4.7.1_react@17.0.2
-      react-reflex: 4.0.9_sfoxds7t5ydpegc3knd667wn6m
+      react-error-boundary: 4.0.3_react@17.0.2
+      react-icons: 4.8.0_react@17.0.2
+      react-reflex: 4.0.12_sfoxds7t5ydpegc3knd667wn6m
       react-slider: 2.0.4_react@17.0.2
       react-suspense-fetch: 0.4.1
       three: 0.141.0
-      zustand: 4.1.5_react@17.0.2
+      zustand: 4.3.7_react@17.0.2
     transitivePeerDependencies:
       - debug
       - immer
       - js-cookie
     dev: false
 
-  /@h5web/h5wasm/7.0.0_v6np5sctutpiswsic6secylrte:
-    resolution: {integrity: sha512-NoXwe2+AZQxSGciQmjw7j8YQWSvvXIArRyWPmNfX5upwFPGNtL0BsmskFeW9gpQhnXnNp0z79aw/aXOlOycOIg==}
+  /@h5web/h5wasm/7.1.0_us572w4v6dabsn6wrxmocc5w5u:
+    resolution: {integrity: sha512-vKbzbKtt2BSjW8Ourm2wa1vw4BqFCLy93CHECU8SikVytfIWaOoahJhB4advw7+fm0oDNjKW+2aC+DW8CLGKtA==}
     peerDependencies:
-      '@h5web/app': 7.0.0
+      '@h5web/app': 7.1.0
       react: '>=16'
     dependencies:
-      '@h5web/app': 7.0.0_sfoxds7t5ydpegc3knd667wn6m
-      h5wasm: 0.4.7
-      nanoid: 4.0.0
+      '@h5web/app': 7.1.0_sfoxds7t5ydpegc3knd667wn6m
+      h5wasm: 0.4.10
+      nanoid: 4.0.2
       react: 17.0.2
     dev: false
 
-  /@h5web/lib/7.0.0_ec7apzrlzucnkzulcswl7v7zfu:
-    resolution: {integrity: sha512-tObc+rUJYVG7eeZCCGzJHl1WpNfos9vZxwoWRUHvSyaYKXamZfEIt0R1BDsdg6ZKdqLXYp4shwA8fhqfBFgtBA==}
+  /@h5web/lib/7.1.0_ec7apzrlzucnkzulcswl7v7zfu:
+    resolution: {integrity: sha512-UVh7xB5B9faoZzfCQCzFUULT63XVJOp7ktcje1qvCr63DM0aHj154ApTybPXtpfDD4kv0vi7yb4Moqps1VK/zQ==}
     peerDependencies:
       '@react-three/fiber': '>=6.0.14'
       react: '>=16'
       react-dom: '>=16'
       three: '>=0.138'
     dependencies:
-      '@react-hookz/web': 22.0.0_sfoxds7t5ydpegc3knd667wn6m
+      '@react-hookz/web': 23.0.0_sfoxds7t5ydpegc3knd667wn6m
       '@react-three/fiber': 7.0.26_weaphyuqmcotibvxgot4zxypyi
-      '@visx/axis': 3.0.0_react@17.0.2
-      '@visx/drag': 3.0.0_react@17.0.2
-      '@visx/grid': 3.0.0_react@17.0.2
+      '@visx/axis': 3.1.0_react@17.0.2
+      '@visx/drag': 3.0.1_react@17.0.2
+      '@visx/grid': 3.0.1_react@17.0.2
       '@visx/scale': 3.0.0
       '@visx/shape': 3.0.0_react@17.0.2
-      '@visx/tooltip': 3.0.0_sfoxds7t5ydpegc3knd667wn6m
-      d3-array: 3.2.1
+      '@visx/tooltip': 3.1.2_sfoxds7t5ydpegc3knd667wn6m
+      d3-array: 3.2.3
       d3-color: 3.1.0
       d3-format: 3.1.0
       d3-interpolate: 3.0.1
@@ -381,13 +381,13 @@ packages:
       react: 17.0.2
       react-aria-menubutton: 7.0.3_react@17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-icons: 4.7.1_react@17.0.2
+      react-icons: 4.8.0_react@17.0.2
       react-keyed-flatten-children: 1.3.0_react@17.0.2
       react-measure: 2.5.2_sfoxds7t5ydpegc3knd667wn6m
       react-slider: 2.0.4_react@17.0.2
       react-window: 1.8.8_sfoxds7t5ydpegc3knd667wn6m
       three: 0.141.0
-      zustand: 4.1.5_react@17.0.2
+      zustand: 4.3.7_react@17.0.2
     transitivePeerDependencies:
       - immer
       - js-cookie
@@ -454,8 +454,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@react-hookz/web/22.0.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-jl4JgUXaiSvvDVQD2z/rq2/RaykjjLrAZxHOEQj2H38j4UFWIVhv5oKUH8yrKF4wX6tMX9gdrj62f9yGq/nSaQ==}
+  /@react-hookz/web/23.0.0_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-diBtlo17CJtZJ/Yb8veri7hZL7QPnqNZ+IAMHWWSb//nq+Z3XDHaXcozH7cyvMZj4gYwQeY/L/H4298etHxu1Q==}
     peerDependencies:
       js-cookie: ^3.0.1
       react: ^16.8 || ^17 || ^18
@@ -502,14 +502,14 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@types/d3-color/1.4.2:
-    resolution: {integrity: sha512-fYtiVLBYy7VQX+Kx7wU/uOIkGQn8aAEY8oWMoyja3N4dLd8Yf6XgSIR/4yWvMuveNOH5VShnqCgRqqh/UNanBA==}
+  /@types/d3-color/3.1.0:
+    resolution: {integrity: sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==}
     dev: false
 
   /@types/d3-interpolate/3.0.1:
     resolution: {integrity: sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==}
     dependencies:
-      '@types/d3-color': 1.4.2
+      '@types/d3-color': 3.1.0
     dev: false
 
   /@types/d3-path/1.0.9:
@@ -532,44 +532,44 @@ packages:
     resolution: {integrity: sha512-9MVYlmIgmRR31C5b4FVSWtuMmBHh2mOWQYfl7XAYOa8dsnb7iEmUmRSWSFgXFtkjxO65d7hTUHQC+RhR/9IWFg==}
     dev: false
 
-  /@types/lodash/4.14.182:
-    resolution: {integrity: sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==}
+  /@types/lodash/4.14.192:
+    resolution: {integrity: sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==}
     dev: false
 
-  /@types/node/16.11.7:
-    resolution: {integrity: sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==}
+  /@types/node/18.15.11:
+    resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}
     dev: true
 
   /@types/prop-types/15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
 
-  /@types/react-dom/17.0.10:
-    resolution: {integrity: sha512-8oz3NAUId2z/zQdFI09IMhQPNgIbiP8Lslhv39DIDamr846/0spjZK0vnrMak0iB8EKb9QFTTIdg2Wj2zH5a3g==}
+  /@types/react-dom/17.0.19:
+    resolution: {integrity: sha512-PiYG40pnQRdPHnlf7tZnp0aQ6q9tspYr72vD61saO6zFCybLfMqwUCN0va1/P+86DXn18ZWeW30Bk7xlC5eEAQ==}
     dependencies:
-      '@types/react': 17.0.33
+      '@types/react': 17.0.58
 
-  /@types/react/17.0.33:
-    resolution: {integrity: sha512-pLWntxXpDPaU+RTAuSGWGSEL2FRTNyRQOjSWDke/rxRg14ncsZvx8AKWMWZqvc1UOaJIAoObdZhAWvRaHFi5rw==}
+  /@types/react/17.0.58:
+    resolution: {integrity: sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==}
     dependencies:
       '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
+      '@types/scheduler': 0.16.3
       csstype: 3.1.0
 
-  /@types/scheduler/0.16.2:
-    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
+  /@types/scheduler/0.16.3:
+    resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
 
   /@types/vscode/1.46.0:
     resolution: {integrity: sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==}
     dev: true
 
-  /@visx/axis/3.0.0_react@17.0.2:
-    resolution: {integrity: sha512-5vvTPPFUcIZ78ttd8MJLlWuwT+UmvO/sBZIzY2TYETda7ebDiMT/IkFHhIMtr1j/ugvqmcHKVW5jlAJCTnrOCw==}
+  /@visx/axis/3.1.0_react@17.0.2:
+    resolution: {integrity: sha512-JDj/1VYx0JO0pHFtwoFtYcnqdoZFh/dpHImEl169S5nTslSFlIoNTXA/ekpBP6ELkEZ59gmF1X5k29x6MFBwCA==}
     peerDependencies:
       react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
-      '@types/react': 17.0.33
+      '@types/react': 17.0.58
       '@visx/group': 3.0.0_react@17.0.2
-      '@visx/point': 3.0.0
+      '@visx/point': 3.0.1
       '@visx/scale': 3.0.0
       '@visx/shape': 3.0.0_react@17.0.2
       '@visx/text': 3.0.0_react@17.0.2
@@ -584,8 +584,8 @@ packages:
       react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
       react-dom: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
-      '@types/react': 17.0.33
-      '@types/react-dom': 17.0.10
+      '@types/react': 17.0.58
+      '@types/react-dom': 17.0.19
       prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -598,34 +598,34 @@ packages:
       d3-shape: 1.3.7
     dev: false
 
-  /@visx/drag/3.0.0_react@17.0.2:
-    resolution: {integrity: sha512-sy/3xQQKwuck5MVwg68LXX3UQNS495sGCvUog7LiUnbOBGWvmKy6x1kcjDULm3TB9qg3R2av7qoEHJwW/u1jTQ==}
+  /@visx/drag/3.0.1_react@17.0.2:
+    resolution: {integrity: sha512-yi2AB/unUfNYBRKS4pmUOuz8MjaAAYjsQGYcD/s4LqeQjd+lBZF7CuNcYZ/maGNQAEUfgLr2czIzADanOMtMaw==}
     peerDependencies:
       react: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
-      '@types/react': 17.0.33
-      '@visx/event': 3.0.0
-      '@visx/point': 3.0.0
+      '@types/react': 17.0.58
+      '@visx/event': 3.0.1
+      '@visx/point': 3.0.1
       prop-types: 15.8.1
       react: 17.0.2
     dev: false
 
-  /@visx/event/3.0.0:
-    resolution: {integrity: sha512-Jr1+HwyfaTfhzsge75PiMc/ug1V9ip2t/yg9ckDWwzT8kcdk0BHCkxKqSrXKokKd2XNJ8XrJVwZZVcQaFg0ctA==}
+  /@visx/event/3.0.1:
+    resolution: {integrity: sha512-tK1EUYQLLStBuoCMbm8LJ3VbDyCVI8HjT0pMRQxm+C75FSIVWvrThgrfrC9sWOFnEMEYWspZO7hI5zjsPKjLQA==}
     dependencies:
-      '@types/react': 17.0.33
-      '@visx/point': 3.0.0
+      '@types/react': 17.0.58
+      '@visx/point': 3.0.1
     dev: false
 
-  /@visx/grid/3.0.0_react@17.0.2:
-    resolution: {integrity: sha512-NsoHjdLYY3PDeEdRNBe2a7eiVxfG50lzZOM/zt/5kb5F4Ag4xzvgy+E32gBa2m9kSyALzTMiMfIHjQ4/LbFQdg==}
+  /@visx/grid/3.0.1_react@17.0.2:
+    resolution: {integrity: sha512-cln5CVvFG58C5Uz1Uf0KRBFmGmgD1NALOQdYDu5yPsTuY2yLzVYPvCIlYBMdUtE0uzfNq972SmkZHfZYs03jxQ==}
     peerDependencies:
       react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
-      '@types/react': 17.0.33
+      '@types/react': 17.0.58
       '@visx/curve': 3.0.0
       '@visx/group': 3.0.0_react@17.0.2
-      '@visx/point': 3.0.0
+      '@visx/point': 3.0.1
       '@visx/scale': 3.0.0
       '@visx/shape': 3.0.0_react@17.0.2
       classnames: 2.3.1
@@ -638,14 +638,14 @@ packages:
     peerDependencies:
       react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
-      '@types/react': 17.0.33
+      '@types/react': 17.0.58
       classnames: 2.3.1
       prop-types: 15.8.1
       react: 17.0.2
     dev: false
 
-  /@visx/point/3.0.0:
-    resolution: {integrity: sha512-OWGTC9KZK63PSCXHpfFzez7InHW+eMdofVVyPUCtB3FG8Xr8qZbH8Ho17PH4e45AvGebOGW1F6ww391I1AV5fw==}
+  /@visx/point/3.0.1:
+    resolution: {integrity: sha512-S5WOBMgEP2xHcgs3A2BFB2vwzrk0tMmn3PGZAbQJ+lu4HlnalDP72klUnxLTH8xclNNvpUHtHM5eLIJXyHx6Pw==}
     dev: false
 
   /@visx/scale/3.0.0:
@@ -666,8 +666,8 @@ packages:
     dependencies:
       '@types/d3-path': 1.0.9
       '@types/d3-shape': 1.3.8
-      '@types/lodash': 4.14.182
-      '@types/react': 17.0.33
+      '@types/lodash': 4.14.192
+      '@types/react': 17.0.58
       '@visx/curve': 3.0.0
       '@visx/group': 3.0.0_react@17.0.2
       '@visx/scale': 3.0.0
@@ -684,8 +684,8 @@ packages:
     peerDependencies:
       react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
-      '@types/lodash': 4.14.182
-      '@types/react': 17.0.33
+      '@types/lodash': 4.14.192
+      '@types/react': 17.0.58
       classnames: 2.3.1
       lodash: 4.17.21
       prop-types: 15.8.1
@@ -693,13 +693,13 @@ packages:
       reduce-css-calc: 1.3.0
     dev: false
 
-  /@visx/tooltip/3.0.0_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-a+ZzlE/vVxQgW83k/Ypj721K09IKG4JRHVb7YDxiQnAawkJe9rkTxGoAIXD6PrqvERa+rSISgUWHAxuee5MnhA==}
+  /@visx/tooltip/3.1.2_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-p46qztGRNkEDbxzc3V1virahvz3UQ29TzddUjA0oaTIBCrOd9UJuLvv1Tq9OpeUYPdbrO/ZRwaEeri2pbwv04Q==}
     peerDependencies:
       react: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
       react-dom: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
-      '@types/react': 17.0.33
+      '@types/react': 17.0.58
       '@visx/bounds': 3.0.0_sfoxds7t5ydpegc3knd667wn6m
       classnames: 2.3.1
       prop-types: 15.8.1
@@ -744,8 +744,8 @@ packages:
       - debug
     dev: false
 
-  /axios/1.2.2:
-    resolution: {integrity: sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==}
+  /axios/1.3.4:
+    resolution: {integrity: sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==}
     dependencies:
       follow-redirects: 1.15.1
       form-data: 4.0.0
@@ -828,8 +828,8 @@ packages:
       internmap: 1.0.1
     dev: false
 
-  /d3-array/3.2.1:
-    resolution: {integrity: sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==}
+  /d3-array/3.2.3:
+    resolution: {integrity: sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==}
     engines: {node: '>=12'}
     dependencies:
       internmap: 2.0.3
@@ -868,7 +868,7 @@ packages:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
     dependencies:
-      d3-array: 3.2.1
+      d3-array: 3.2.3
       d3-format: 3.1.0
       d3-interpolate: 3.0.1
       d3-time: 3.0.0
@@ -898,7 +898,7 @@ packages:
     resolution: {integrity: sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==}
     engines: {node: '>=12'}
     dependencies:
-      d3-array: 3.2.1
+      d3-array: 3.2.3
     dev: false
 
   /debounce/1.2.1:
@@ -1201,8 +1201,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /h5wasm/0.4.7:
-    resolution: {integrity: sha512-bBwBkK57iMXdnVDIdqJU4BR3iEtbo9vsXh1r8tAyO079U5DakO08cHJqZ8o0/xcsNEdEoXaKuCcBpUpP1dsKKQ==}
+  /h5wasm/0.4.10:
+    resolution: {integrity: sha512-JQpErzcw4vLqMbtM9VAXoRnmmvp4uQUlCdXzuQ6MDaafRusFL4FMmpDfsSk2QiiBLb7Sndx9CAvydgk/iKSD9g==}
     dev: false
 
   /has-flag/3.0.0:
@@ -1300,8 +1300,8 @@ packages:
     hasBin: true
     dev: true
 
-  /nanoid/4.0.0:
-    resolution: {integrity: sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==}
+  /nanoid/4.0.2:
+    resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
     engines: {node: ^14 || ^16 || >=18}
     hasBin: true
     dev: false
@@ -1354,8 +1354,8 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
-  /prettier/2.7.1:
-    resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
+  /prettier/2.8.7:
+    resolution: {integrity: sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: true
@@ -1404,8 +1404,17 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-icons/4.7.1_react@17.0.2:
-    resolution: {integrity: sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==}
+  /react-error-boundary/4.0.3_react@17.0.2:
+    resolution: {integrity: sha512-IzNKP/ViHWp2QRDgsDMirEcf0XLsLueN6Wgzm1TVwgbAH+paX8Z42VyKvZcFFRHgd+rPK2P4TLrOrHC/dommew==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.18.6
+      react: 17.0.2
+    dev: false
+
+  /react-icons/4.8.0_react@17.0.2:
+    resolution: {integrity: sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==}
     peerDependencies:
       react: '*'
     dependencies:
@@ -1455,8 +1464,8 @@ packages:
       scheduler: 0.20.2
     dev: false
 
-  /react-reflex/4.0.9_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-XFTNRekFK4ul8mzVd1lniKT/SI0FvNYhXyLNl5gagS1i3iW9QKlpFYcRfVhZlxxaYHb8UyLOs3+H4Ay5cjtbxQ==}
+  /react-reflex/4.0.12_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-sYgX0rW7xuGcs99WwXB/fPlPLzr3kiZhlTF+5Oijz+e2Hh64WlxIJdbrXMr4yA+vtn9Zi4vN/jF2CP7drWAAAQ==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
@@ -1695,8 +1704,8 @@ packages:
       react: 17.0.2
     dev: false
 
-  /zustand/4.1.5_react@17.0.2:
-    resolution: {integrity: sha512-PsdRT8Bvq22Yyh1tvpgdHNE7OAeFKqJXUxtJvj1Ixw2B9O2YZ1M34ImQ+xyZah4wZrR4lENMoDUutKPpyXCQ/Q==}
+  /zustand/4.3.7_react@17.0.2:
+    resolution: {integrity: sha512-dY8ERwB9Nd21ellgkBZFhudER8KVlelZm8388B5nDAXhO/+FZDhYMuRnqDgu5SYyRgz/iaf8RKnbUs/cHfOGlQ==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
       immer: '>=9.0'


### PR DESCRIPTION
- Upgrade dev engine to Node 18
- [H5Web@7.1.0](https://github.com/silx-kit/h5web/releases/tag/v7.1.0) brings the ability to search for entities by text in the sidebar.
- Add CI workflow to run prettier and build the front-end app and the extension.

