### PR TITLE
Add support for 7 compression plugins

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 
   "typescript.tsdk": "node_modules/typescript/lib",

--- a/app/Viewer.tsx
+++ b/app/Viewer.tsx
@@ -1,7 +1,7 @@
 import { App } from '@h5web/app';
 import { H5WasmProvider } from '@h5web/h5wasm';
 import { suspend } from 'suspend-react';
-import { getExportURL } from './utils';
+import { getExportURL, getPlugin } from './utils';
 import { type FileInfo } from '../src/models.js';
 
 interface Props {
@@ -10,6 +10,7 @@ interface Props {
 
 function Viewer(props: Props) {
   const { fileInfo } = props;
+  const { supportedPlugins } = fileInfo;
 
   const buffer = suspend(async () => {
     const res = await fetch(fileInfo.uri);
@@ -21,6 +22,7 @@ function Viewer(props: Props) {
       filename={fileInfo.name}
       buffer={buffer}
       getExportURL={getExportURL}
+      getPlugin={async (name) => getPlugin(supportedPlugins[name])}
     >
       <App />
     </H5WasmProvider>

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -56,3 +56,14 @@ export const getExportURL: GetExportURL = (
 
   return undefined;
 };
+
+export async function getPlugin(
+  url: string | undefined
+): Promise<ArrayBuffer | undefined> {
+  if (!url) {
+    return undefined;
+  }
+
+  const response = await fetch(url);
+  return response.arrayBuffer();
+}

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "Visualization"
   ],
   "engines": {
-    "node": "18.x",
-    "pnpm": ">=8.6.0",
+    "node": "20.x",
+    "pnpm": "8.x",
     "vscode": ">=1.47.0"
   },
   "activationEvents": [
@@ -59,17 +59,18 @@
   "scripts": {
     "build": "pnpm build:app && pnpm build:extension --minify",
     "build:app": "vite build",
-    "build:extension": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
+    "build:extension": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --loader:.so=file --format=cjs --platform=node",
     "watch": "pnpm build:extension --sourcemap --watch",
     "prettier": "prettier . --cache --check",
     "vscode:prepublish": "pnpm build",
     "pub": "pnpx vsce publish --no-dependencies"
   },
   "dependencies": {
-    "@h5web/app": "10.0.0",
-    "@h5web/h5wasm": "10.0.0",
+    "@h5web/app": "10.1.0",
+    "@h5web/h5wasm": "10.1.0",
     "@react-hookz/web": "15.0.1",
     "axios": "0.27.2",
+    "h5wasm-plugins": "0.0.3",
     "normalize.css": "8.0.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -77,7 +78,7 @@
     "suspend-react": "0.0.8"
   },
   "devDependencies": {
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.10.5",
     "@types/react": "^18.2.25",
     "@types/react-dom": "^18.2.10",
     "@types/vscode": "~1.47.0",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,8 @@
   "engines": {
     "node": "20.x",
     "pnpm": "8.x",
-    "vscode": ">=1.47.0"
+    "vscode": ">=1.86.0"
   },
-  "activationEvents": [
-    "onCustomEditor:h5web.viewer"
-  ],
   "contributes": {
     "customEditors": [
       {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,17 +6,20 @@ settings:
 
 dependencies:
   '@h5web/app':
-    specifier: 10.0.0
-    version: 10.0.0(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+    specifier: 10.1.0
+    version: 10.1.0(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
   '@h5web/h5wasm':
-    specifier: 10.0.0
-    version: 10.0.0(@h5web/app@10.0.0)(react@18.2.0)(typescript@5.2.2)
+    specifier: 10.1.0
+    version: 10.1.0(@h5web/app@10.1.0)(react@18.2.0)(typescript@5.2.2)
   '@react-hookz/web':
     specifier: 15.0.1
     version: 15.0.1(react-dom@18.2.0)(react@18.2.0)
   axios:
     specifier: 0.27.2
     version: 0.27.2
+  h5wasm-plugins:
+    specifier: 0.0.3
+    version: 0.0.3
   normalize.css:
     specifier: 8.0.1
     version: 8.0.1
@@ -35,8 +38,8 @@ dependencies:
 
 devDependencies:
   '@types/node':
-    specifier: ^18.15.11
-    version: 18.15.11
+    specifier: ^20.10.5
+    version: 20.10.5
   '@types/react':
     specifier: ^18.2.25
     version: 18.2.25
@@ -335,8 +338,8 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@h5web/app@10.0.0(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-50qD9DUy/VydKoOPOMrC+cCE/22qkyrXxsaYAmRbFZSvvbxbuICbg3O/roVeBdtY/UYZ8/w1CZiSQS/2LnCJRw==}
+  /@h5web/app@10.1.0(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-M0PDOFeCikcC/BGMbr4opsd5vEQgAtj83Gc2egmhF1MVjTdFBvl9YipdaLRlLnDpmK/xMOXwuoE5vbxqCvBS6g==}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
@@ -345,10 +348,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@h5web/lib': 10.0.0(@react-three/fiber@8.14.1)(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(three@0.156.1)(typescript@5.2.2)
+      '@h5web/lib': 10.1.0(@react-three/fiber@8.15.12)(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(three@0.159.0)(typescript@5.2.2)
       '@react-hookz/web': 23.1.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-three/fiber': 8.14.1(react-dom@18.2.0)(react@18.2.0)(three@0.156.1)
-      axios: 1.5.0
+      '@react-three/fiber': 8.15.12(react-dom@18.2.0)(react@18.2.0)(three@0.159.0)
+      axios: 1.6.2
       d3-format: 3.1.0
       lodash: 4.17.21
       ndarray: 1.0.19
@@ -356,13 +359,13 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-error-boundary: 4.0.11(react@18.2.0)
-      react-icons: 4.11.0(react@18.2.0)
+      react-icons: 4.12.0(react@18.2.0)
       react-reflex: 4.1.0(react-dom@18.2.0)(react@18.2.0)
       react-slider: 2.0.4(react@18.2.0)
       react-suspense-fetch: 0.4.1
-      three: 0.156.1
+      three: 0.159.0
       typescript: 5.2.2
-      zustand: 4.4.1(@types/react@18.2.25)(react@18.2.0)
+      zustand: 4.4.7(@types/react@18.2.25)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - debug
@@ -375,25 +378,25 @@ packages:
       - react-native
     dev: false
 
-  /@h5web/h5wasm@10.0.0(@h5web/app@10.0.0)(react@18.2.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-ddK0X55ioao7yE36zYEeVfJf6xpw472/sLKnI844K6426On+9ua9oKkPTZy7YwrUrE8ztUMYoTj/V57xNm0TZA==}
+  /@h5web/h5wasm@10.1.0(@h5web/app@10.1.0)(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-FiAuiGHKSGWW4x3kV7Ezrf5AICLpmw7WvGsY5JerKEb8YqyvbS1jB0mcHcKjYDsDWRVU0xqltRLflCKLGBIVPw==}
     peerDependencies:
-      '@h5web/app': 10.0.0
+      '@h5web/app': 10.1.0
       react: '>=18'
       typescript: '>=4.5'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@h5web/app': 10.0.0(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      h5wasm: 0.6.2
-      nanoid: 5.0.1
+      '@h5web/app': 10.1.0(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      h5wasm: 0.7.0
+      nanoid: 5.0.4
       react: 18.2.0
       typescript: 5.2.2
     dev: false
 
-  /@h5web/lib@10.0.0(@react-three/fiber@8.14.1)(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(three@0.156.1)(typescript@5.2.2):
-    resolution: {integrity: sha512-rN0zcvhLCPL+pzZkdpxaelCgA2rQ1RU0wnYfrbOfMQFW9lSxpmLekQcAaN/dJgGSsc7uMQ8qoxglDvkyx18MPA==}
+  /@h5web/lib@10.1.0(@react-three/fiber@8.15.12)(@types/react@18.2.25)(react-dom@18.2.0)(react@18.2.0)(three@0.159.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-wVZMknpeqjBGrKm8XbuDTkKhv1mNQot0DoPfQmHQWJXzwvL23acD9kCnWpswKkz6R9f2XAdQAYeFPMLmsW5u1g==}
     peerDependencies:
       '@react-three/fiber': '>=8'
       react: '>=18'
@@ -405,12 +408,12 @@ packages:
         optional: true
     dependencies:
       '@react-hookz/web': 23.1.0(react-dom@18.2.0)(react@18.2.0)
-      '@react-three/fiber': 8.14.1(react-dom@18.2.0)(react@18.2.0)(three@0.156.1)
-      '@visx/axis': 3.3.0(react@18.2.0)
+      '@react-three/fiber': 8.15.12(react-dom@18.2.0)(react@18.2.0)(three@0.159.0)
+      '@visx/axis': 3.5.0(react@18.2.0)
       '@visx/drag': 3.3.0(react@18.2.0)
-      '@visx/grid': 3.3.0(react@18.2.0)
-      '@visx/scale': 3.3.0
-      '@visx/shape': 3.3.0(react@18.2.0)
+      '@visx/grid': 3.5.0(react@18.2.0)
+      '@visx/scale': 3.5.0
+      '@visx/shape': 3.5.0(react@18.2.0)
       '@visx/tooltip': 3.3.0(react-dom@18.2.0)(react@18.2.0)
       d3-array: 3.2.4
       d3-color: 3.1.0
@@ -424,14 +427,14 @@ packages:
       react: 18.2.0
       react-aria-menubutton: 7.0.3(react@18.2.0)
       react-dom: 18.2.0(react@18.2.0)
-      react-icons: 4.11.0(react@18.2.0)
-      react-keyed-flatten-children: 2.2.1(react@18.2.0)
+      react-icons: 4.12.0(react@18.2.0)
+      react-keyed-flatten-children: 3.0.0(react@18.2.0)
       react-measure: 2.5.2(react-dom@18.2.0)(react@18.2.0)
       react-slider: 2.0.4(react@18.2.0)
-      react-window: 1.8.9(react-dom@18.2.0)(react@18.2.0)
-      three: 0.156.1
+      react-window: 1.8.10(react-dom@18.2.0)(react@18.2.0)
+      three: 0.159.0
       typescript: 5.2.2
-      zustand: 4.4.1(@types/react@18.2.25)(react@18.2.0)
+      zustand: 4.4.7(@types/react@18.2.25)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -514,8 +517,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@react-three/fiber@8.14.1(react-dom@18.2.0)(react@18.2.0)(three@0.156.1):
-    resolution: {integrity: sha512-Ky/FiCyJiyaI8bd+vckzgkHgKDSQDOcSSUVFOHCuCO9XOLb7Ebs6lof2hPpFa1HkaeE5ZIbTWIprvN0QqdPF0w==}
+  /@react-three/fiber@8.15.12(react-dom@18.2.0)(react@18.2.0)(three@0.159.0):
+    resolution: {integrity: sha512-yg0CyXVHIdSbNjM/GAgDrGJnKLTsfTlaR5FoJGEh9IgVKptOoudnFZhBt/Cau4rzx2X6eLmB1+aWOm1dEHSUpg==}
     peerDependencies:
       expo: '>=43.0'
       expo-asset: '>=8.4'
@@ -541,7 +544,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.6
       '@types/react-reconciler': 0.26.7
+      '@types/webxr': 0.5.10
       base64-js: 1.5.1
+      buffer: 6.0.3
       its-fine: 1.1.1(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -549,7 +554,7 @@ packages:
       react-use-measure: 2.1.1(react-dom@18.2.0)(react@18.2.0)
       scheduler: 0.21.0
       suspend-react: 0.1.3(react@18.2.0)
-      three: 0.156.1
+      three: 0.159.0
       zustand: 3.7.2(react@18.2.0)
     dev: false
 
@@ -575,6 +580,12 @@ packages:
 
   /@types/d3-format@3.0.1:
     resolution: {integrity: sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==}
+    dev: false
+
+  /@types/d3-geo@3.1.0:
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+    dependencies:
+      '@types/geojson': 7946.0.13
     dev: false
 
   /@types/d3-interpolate@3.0.1:
@@ -607,12 +618,18 @@ packages:
     resolution: {integrity: sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==}
     dev: false
 
+  /@types/geojson@7946.0.13:
+    resolution: {integrity: sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==}
+    dev: false
+
   /@types/lodash@4.14.192:
     resolution: {integrity: sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==}
     dev: false
 
-  /@types/node@18.15.11:
-    resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}
+  /@types/node@20.10.5:
+    resolution: {integrity: sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /@types/prop-types@15.7.5:
@@ -653,16 +670,20 @@ packages:
     resolution: {integrity: sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==}
     dev: true
 
-  /@visx/axis@3.3.0(react@18.2.0):
-    resolution: {integrity: sha512-O7fPQtpum4NEsb8u2/eTeOSt8CvAczoehVQbJtDLyDNio6yLvytfHtRKxOsl/FHjFnPYgBjkQtwiKiR5oSjP3g==}
+  /@types/webxr@0.5.10:
+    resolution: {integrity: sha512-n3u5sqXQJhf1CS68mw3Wf16FQ4cRPNBBwdYLFzq3UddiADOim1Pn3Y6PBdDilz1vOJF3ybLxJ8ZEDlLIzrOQZg==}
+    dev: false
+
+  /@visx/axis@3.5.0(react@18.2.0):
+    resolution: {integrity: sha512-vaY/CGk9+iQL1BFlHd5muIAuAjpPKLwtt6HwpITErW+cImjQJlNgYdgbwDCyuJMmJqXOlC9byWlmF+iI1dOPYg==}
     peerDependencies:
       react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
       '@types/react': 18.2.25
       '@visx/group': 3.3.0(react@18.2.0)
       '@visx/point': 3.3.0
-      '@visx/scale': 3.3.0
-      '@visx/shape': 3.3.0(react@18.2.0)
+      '@visx/scale': 3.5.0
+      '@visx/shape': 3.5.0(react@18.2.0)
       '@visx/text': 3.3.0(react@18.2.0)
       classnames: 2.3.1
       prop-types: 15.8.1
@@ -708,8 +729,8 @@ packages:
       '@visx/point': 3.3.0
     dev: false
 
-  /@visx/grid@3.3.0(react@18.2.0):
-    resolution: {integrity: sha512-wHzxevZfNreU21CHA2/CFLwJeBsetwXQJLxYmc2DotTFHn07n3XJtGCjMVdrmUKfoa/N8cPcFBehuWjnWWpXBg==}
+  /@visx/grid@3.5.0(react@18.2.0):
+    resolution: {integrity: sha512-i1pdobTE223ItMiER3q4ojIaZWja3vg46TkS6FotnBZ4c0VRDHSrALQPdi0na+YEgppASWCQ2WrI/vD6mIkhSg==}
     peerDependencies:
       react: ^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
@@ -717,8 +738,8 @@ packages:
       '@visx/curve': 3.3.0
       '@visx/group': 3.3.0(react@18.2.0)
       '@visx/point': 3.3.0
-      '@visx/scale': 3.3.0
-      '@visx/shape': 3.3.0(react@18.2.0)
+      '@visx/scale': 3.5.0
+      '@visx/shape': 3.5.0(react@18.2.0)
       classnames: 2.3.1
       prop-types: 15.8.1
       react: 18.2.0
@@ -739,14 +760,14 @@ packages:
     resolution: {integrity: sha512-03eBBIJarkmX79WbeEGTUZwmS5/MUuabbiM9KfkGS9pETBTWkp1DZtEHZdp5z34x5TDQVLSi0rk1Plg3/8RtDg==}
     dev: false
 
-  /@visx/scale@3.3.0:
-    resolution: {integrity: sha512-H569k7eQEUcFE/X1Zojcb4rUwxurIU4yso21uAuKvXnZcGpDOTr/3YXXHb1JJqOKfLcZtYZWXok6QVDj5ZGtCw==}
+  /@visx/scale@3.5.0:
+    resolution: {integrity: sha512-xo3zrXV2IZxrMq9Y9RUVJUpd93h3NO/r/y3GVi5F9AsbOzOhsLIbsPkunhO9mpUSR8LZ9TiumLEBrY+3frRBSg==}
     dependencies:
-      '@visx/vendor': 3.3.0
+      '@visx/vendor': 3.5.0
     dev: false
 
-  /@visx/shape@3.3.0(react@18.2.0):
-    resolution: {integrity: sha512-+ojOlcoMnbC16zhwK7HyK4dIB9sUJILQfVNBBNw8TBckCsly+S1WdBKZ+RZvQDppNr2YuiQLsZpr3W9zZJaHtg==}
+  /@visx/shape@3.5.0(react@18.2.0):
+    resolution: {integrity: sha512-DP3t9jBQ7dSE3e6ptA1xO4QAIGxO55GrY/6P+S6YREuQGjZgq20TLYLAsiaoPEzFSS4tp0m12ZTPivWhU2VBTw==}
     peerDependencies:
       react: ^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
@@ -756,7 +777,7 @@ packages:
       '@types/react': 18.2.25
       '@visx/curve': 3.3.0
       '@visx/group': 3.3.0(react@18.2.0)
-      '@visx/scale': 3.3.0
+      '@visx/scale': 3.5.0
       classnames: 2.3.1
       d3-path: 1.0.9
       d3-shape: 1.3.7
@@ -794,13 +815,14 @@ packages:
       react-use-measure: 2.1.1(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
-  /@visx/vendor@3.3.0:
-    resolution: {integrity: sha512-Xf4ziUWP3oUN/91ROYgJr2JJ6tET+j4jgVfa0Mj9XFpFJeY7U8aEwrNDM2mbR1draktCFNyy/OQAaFa69pr8qQ==}
+  /@visx/vendor@3.5.0:
+    resolution: {integrity: sha512-yt3SEZRVmt36+APsCISSO9eSOtzQkBjt+QRxNRzcTWuzwMAaF3PHCCSe31++kkpgY9yFoF+Gfes1TBe5NlETiQ==}
     dependencies:
       '@types/d3-array': 3.0.3
       '@types/d3-color': 3.1.0
       '@types/d3-delaunay': 6.0.1
       '@types/d3-format': 3.0.1
+      '@types/d3-geo': 3.1.0
       '@types/d3-interpolate': 3.0.1
       '@types/d3-scale': 4.0.2
       '@types/d3-time': 3.0.0
@@ -809,6 +831,7 @@ packages:
       d3-color: 3.1.0
       d3-delaunay: 6.0.2
       d3-format: 3.1.0
+      d3-geo: 3.1.0
       d3-interpolate: 3.0.1
       d3-scale: 4.0.2
       d3-time: 3.1.0
@@ -852,8 +875,8 @@ packages:
       - debug
     dev: false
 
-  /axios@1.5.0:
-    resolution: {integrity: sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==}
+  /axios@1.6.2:
+    resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
     dependencies:
       follow-redirects: 1.15.1
       form-data: 4.0.0
@@ -884,6 +907,13 @@ packages:
       node-releases: 2.0.5
       update-browserslist-db: 1.0.4(browserslist@4.21.1)
     dev: true
+
+  /buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
 
   /caniuse-lite@1.0.30001363:
     resolution: {integrity: sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==}
@@ -963,6 +993,13 @@ packages:
   /d3-format@3.1.0:
     resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
     engines: {node: '>=12'}
+    dev: false
+
+  /d3-geo@3.1.0:
+    resolution: {integrity: sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==}
+    engines: {node: '>=12'}
+    dependencies:
+      d3-array: 3.2.4
     dev: false
 
   /d3-interpolate@3.0.1:
@@ -1317,8 +1354,18 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /h5wasm@0.6.2:
-    resolution: {integrity: sha512-aVDa+7MNyfQ2IL/fa5g4YeGZAdahBIAZpjpd/toO9q5yRGxTo2KBwDCxyD/RDFKIvHQMPqOhZaRzoucOSdlPpQ==}
+  /h5wasm-plugins@0.0.3:
+    resolution: {integrity: sha512-hOI1ERa6QfjrN/AWJW0mqFaAU4D4NtzYXjb03h7f1MufkIzCkYo/bZoB7NZy+Qy9vHsxL31rz7hNlZCPouf+tQ==}
+    dependencies:
+      h5wasm: 0.6.10
+    dev: false
+
+  /h5wasm@0.6.10:
+    resolution: {integrity: sha512-GxBWGVxBftyq67kAbS4WPmTH3a8hGKigdMm+IVJ7tLY7BHj+nqDTUKO9RmmPBHy6Pvq5uW1YpIJr/oGanw+RyQ==}
+    dev: false
+
+  /h5wasm@0.7.0:
+    resolution: {integrity: sha512-5nFOpklF0HoYCS4Xd4lbYPl3UHolc1VxtW1nKz5BEYi5pingqVPjJVTwnNiIOqYDKuXmxzYBr2wsV3BxjdVZkw==}
     dev: false
 
   /has-flag@3.0.0:
@@ -1332,6 +1379,10 @@ packages:
     dependencies:
       function-bind: 1.1.1
     dev: true
+
+  /ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+    dev: false
 
   /internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
@@ -1421,8 +1472,8 @@ packages:
     hasBin: true
     dev: true
 
-  /nanoid@5.0.1:
-    resolution: {integrity: sha512-vWeVtV5Cw68aML/QaZvqN/3QQXc6fBfIieAlu05m7FZW2Dgb+3f0xc0TTxuJW+7u30t7iSDTV/j3kVI0oJqIfQ==}
+  /nanoid@5.0.4:
+    resolution: {integrity: sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==}
     engines: {node: ^18 || >=20}
     hasBin: true
     dev: false
@@ -1533,8 +1584,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-icons@4.11.0(react@18.2.0):
-    resolution: {integrity: sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==}
+  /react-icons@4.12.0(react@18.2.0):
+    resolution: {integrity: sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==}
     peerDependencies:
       react: '*'
     dependencies:
@@ -1549,8 +1600,8 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: false
 
-  /react-keyed-flatten-children@2.2.1(react@18.2.0):
-    resolution: {integrity: sha512-6yBLVO6suN8c/OcJk1mzIrUHdeEzf5rtRVBhxEXAHO49D7SlJ70cG4xrSJrBIAG7MMeQ+H/T151mM2dRDNnFaA==}
+  /react-keyed-flatten-children@3.0.0(react@18.2.0):
+    resolution: {integrity: sha512-tSH6gvOyQjt3qtjG+kU9sTypclL1672yjpVufcE3aHNM0FhvjBUQZqsb/awIux4zEuVC3k/DP4p0GdTT/QUt/Q==}
     peerDependencies:
       react: '>=15.0.0'
     dependencies:
@@ -1626,8 +1677,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /react-window@1.8.9(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-+Eqx/fj1Aa5WnhRfj9dJg4VYATGwIUP2ItwItiJ6zboKWA6EX3lYDAXfGF2hyNqplEprhbtjbipiADEcwQ823Q==}
+  /react-window@1.8.10(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==}
     engines: {node: '>8.0.0'}
     peerDependencies:
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
@@ -1747,8 +1798,8 @@ packages:
     resolution: {integrity: sha512-HnA3I2sxRQe/SZgQTQgQvvA17DhfzhBJ1LfSOXZ5VUTbxGLvnAqUef84ZGNNSEbk1ZMEIDeghTHZagJ7LifAgg==}
     dev: false
 
-  /three@0.156.1:
-    resolution: {integrity: sha512-kP7H0FK9d/k6t/XvQ9FO6i+QrePoDcNhwl0I02+wmUJRNSLCUIDMcfObnzQvxb37/0Uc9TDT0T1HgsRRrO6SYQ==}
+  /three@0.159.0:
+    resolution: {integrity: sha512-eCmhlLGbBgucuo4VEA9IO3Qpc7dh8Bd4VKzr7WfW4+8hMcIfoAVi1ev0pJYN9PTTsCslbcKgBwr2wNZ1EvLInA==}
     dev: false
 
   /to-fast-properties@2.0.0:
@@ -1760,6 +1811,10 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
 
   /uniq@1.0.1:
     resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
@@ -1820,8 +1875,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /zustand@4.4.1(@types/react@18.2.25)(react@18.2.0):
-    resolution: {integrity: sha512-QCPfstAS4EBiTQzlaGP1gmorkh/UL1Leaj2tdj+zZCZ/9bm0WS7sI2wnfD5lpOszFqWJ1DcPnGoY8RDL61uokw==}
+  /zustand@4.4.7(@types/react@18.2.25)(react@18.2.0):
+    resolution: {integrity: sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
       '@types/react': '>=16.8'

--- a/src/H5WebViewer.ts
+++ b/src/H5WebViewer.ts
@@ -8,10 +8,9 @@ import {
   window,
   workspace,
 } from 'vscode';
-import { join, basename } from 'path';
-import { writeFileSync, watchFile, unwatchFile } from 'fs';
+import { join, basename, dirname } from 'node:path';
+import { writeFileSync, watchFile, unwatchFile } from 'node:fs';
 import { Message, MessageType } from './models';
-import path = require('path');
 import { getSupportedPlugins } from './plugins';
 
 export default class H5WebViewer
@@ -74,7 +73,7 @@ export default class H5WebViewer
         const { format, name, payload } = evt.data;
 
         const defaultUri = Uri.file(
-          path.join(path.dirname(document.uri.fsPath), `${name}.${format}`)
+          join(dirname(document.uri.fsPath), `${name}.${format}`)
         );
 
         const saveUri = await window.showSaveDialog({

--- a/src/H5WebViewer.ts
+++ b/src/H5WebViewer.ts
@@ -12,6 +12,7 @@ import { join, basename } from 'path';
 import { writeFileSync, watchFile, unwatchFile } from 'fs';
 import { Message, MessageType } from './models';
 import path = require('path');
+import { getSupportedPlugins } from './plugins';
 
 export default class H5WebViewer
   implements CustomReadonlyEditorProvider<CustomDocument>
@@ -47,16 +48,17 @@ export default class H5WebViewer
         const uri = webview.asWebviewUri(document.uri).toString();
         const name = basename(document.uri.fsPath);
         const { size } = await workspace.fs.stat(document.uri);
+        const supportedPlugins = getSupportedPlugins(webview);
 
         webview.postMessage({
           type: MessageType.FileInfo,
-          data: { uri, name, size },
+          data: { uri, name, size, supportedPlugins },
         });
 
         function watcher() {
           webview.postMessage({
             type: MessageType.FileInfo,
-            data: { uri, name, size },
+            data: { uri, name, size, supportedPlugins },
           });
         }
 

--- a/src/esbuild-env.d.ts
+++ b/src/esbuild-env.d.ts
@@ -1,0 +1,5 @@
+// HDF5 compression plugins
+declare module '*.so' {
+  const src: string;
+  export default src;
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -15,6 +15,7 @@ export interface FileInfo {
   uri: string;
   name: string;
   size: number;
+  supportedPlugins: Record<string, string>;
 }
 
 export interface Export {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import { Uri, Webview } from 'vscode';
 
 import blosc from 'h5wasm-plugins/plugins/libH5Zblosc.so';

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,0 +1,27 @@
+import { resolve } from 'path';
+import { Uri, Webview } from 'vscode';
+
+import blosc from 'h5wasm-plugins/plugins/libH5Zblosc.so';
+import bz2 from 'h5wasm-plugins/plugins/libH5Zbz2.so';
+import lz4 from 'h5wasm-plugins/plugins/libH5Zlz4.so';
+import lzf from 'h5wasm-plugins/plugins/libH5Zlzf.so';
+import szf from 'h5wasm-plugins/plugins/libH5Zszf.so';
+import zfp from 'h5wasm-plugins/plugins/libH5Zzfp.so';
+import zstd from 'h5wasm-plugins/plugins/libH5Zzstd.so';
+
+function getPluginUri(webview: Webview, plugin: string) {
+  const absPath = resolve(__dirname, '../out', plugin);
+  return webview.asWebviewUri(Uri.file(absPath)).toString();
+}
+
+export function getSupportedPlugins(webview: Webview): Record<string, string> {
+  return {
+    blosc: getPluginUri(webview, blosc),
+    bz2: getPluginUri(webview, bz2),
+    lz4: getPluginUri(webview, lz4),
+    lzf: getPluginUri(webview, lzf),
+    szf: getPluginUri(webview, szf),
+    zfp: getPluginUri(webview, zfp),
+    zstd: getPluginUri(webview, zstd),
+  };
+}


### PR DESCRIPTION
Took me a while to figure out how to fetch the plugin files from the webview, but I got there in the end. Unfortunately, I'm hitting the following issue with some of the larger plugins (LZ4, ZStandard, etc.):

```
hdf5_util.js:8 RangeError: WebAssembly.Compile is disallowed on the main thread, if the buffer size is larger than 4KB.
Use WebAssembly.compile, or compile on a worker thread.
```

The webview fetches the plugin files correctly, and they get written to the Emscripten file system as expected. The problem seems to occur when h5wasm reads the compressed dataset and HDF5 tries to load the appropriate plugin dynamically.

@bmaranville I assume there's no other workaround than to move @h5web/h5wasm to a worker, right?