### PR TITLE
Make H5Web the default editor for Loom files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ following file extensions: `.h5`, `.hdf`, `.hdf5`, `.nx`
 ([NeXus](https://manual.nexusformat.org/index.html)), `.nxs`, `.nx5`, `.nexus`,
 `.cxi`
 ([Coherent X-ray Imaging](https://raw.githubusercontent.com/cxidb/CXI/master/cxi_file_format.pdf)),
-`.nc` ([netCDF4](https://docs.unidata.ucar.edu/nug/current/)), `.nc4`.
+`.nc` ([netCDF4](https://docs.unidata.ucar.edu/nug/current/)), `.nc4`,
+[`.loom`](http://linnarssonlab.org/loompy/format/).
 
 To add more extensions, don't hesitate to
 [open an issue](https://github.com/silx-kit/vscode-h5web/issues/new) or

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "displayName": "H5Web",
         "selector": [
           {
-            "filenamePattern": "*.{h5,hdf,hdf5,nx,nxs,nx5,nexus,cxi,nc,nc4}"
+            "filenamePattern": "*.{h5,hdf,hdf5,nx,nxs,nx5,nexus,cxi,nc,nc4,loom}"
           }
         ],
         "priority": "default"


### PR DESCRIPTION
Requested in `jupyterlab-h5web` https://github.com/silx-kit/jupyterlab-h5web/issues/126, but applies here as well. [Loom](http://linnarssonlab.org/loompy/format/) files are standard HDF5 files, so makes sense for them to open in H5Web out of the box.

As usual, it's possible to revert to the default editor with the following VS Code config if need be:

```json
"workbench.editorAssociations": {
  "*.loom": "default",
},
```