### PR TITLE
Pass supported plugins through JSON script tag

### DIFF
--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
-          version: 8.x
+          version: 9.x
 
       - name: Restore cache 📌
         uses: actions/cache@v3
@@ -56,7 +56,7 @@ jobs:
       - name: Install pnpm ⚙️
         uses: pnpm/action-setup@v2
         with:
-          version: 8.x
+          version: 9.x
 
       - name: Restore cache 📌
         uses: actions/cache@v3

--- a/app/Viewer.tsx
+++ b/app/Viewer.tsx
@@ -10,7 +10,6 @@ interface Props {
 
 function Viewer(props: Props) {
   const { fileInfo } = props;
-  const { supportedPlugins } = fileInfo;
 
   const buffer = suspend(async () => {
     const res = await fetch(fileInfo.uri);
@@ -22,7 +21,7 @@ function Viewer(props: Props) {
       filename={fileInfo.name}
       buffer={buffer}
       getExportURL={getExportURL}
-      getPlugin={async (name) => getPlugin(supportedPlugins[name])}
+      getPlugin={getPlugin}
     >
       <App />
     </H5WasmProvider>

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,9 +1,28 @@
-import type { GetExportURL } from '@h5web/app';
+import { assertNonNull, type GetExportURL } from '@h5web/app';
 import { MessageType } from '../src/models.js';
 import { vscode } from './vscode-api.js';
+import type { Plugin } from '@h5web/h5wasm';
+
+const pluginsScriptElem = document.getElementById('plugins');
+assertNonNull(pluginsScriptElem);
+
+const PLUGINS = JSON.parse(pluginsScriptElem.innerHTML);
 
 // 2 GB = 2 * 1024 * 1024 * 1024 B
 export const MAX_SIZE_IN_BYTES = 2147483648;
+
+export async function getPlugin(
+  name: Plugin
+): Promise<ArrayBuffer | undefined> {
+  const url = PLUGINS[name];
+
+  if (!url) {
+    return undefined;
+  }
+
+  const response = await fetch(url);
+  return response.arrayBuffer();
+}
 
 export const getExportURL: GetExportURL = (
   format,
@@ -56,14 +75,3 @@ export const getExportURL: GetExportURL = (
 
   return undefined;
 };
-
-export async function getPlugin(
-  url: string | undefined
-): Promise<ArrayBuffer | undefined> {
-  if (!url) {
-    return undefined;
-  }
-
-  const response = await fetch(url);
-  return response.arrayBuffer();
-}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "engines": {
     "node": "20.x",
-    "pnpm": "8.x",
+    "pnpm": "9.x",
     "vscode": ">=1.86.0"
   },
   "contributes": {

--- a/src/models.ts
+++ b/src/models.ts
@@ -16,7 +16,6 @@ export interface FileInfo {
   uri: string;
   name: string;
   size: number;
-  supportedPlugins: Record<Plugin, string>;
 }
 
 export interface Export {


### PR DESCRIPTION
Just a quick refactoring so the list of supported plugins is not passed to the webview via the `FileInfo` message but "statically" as JSON in the HTML template.

I also bump pnpm to v9.