### PR TITLE
Allow opening very large files manually from inside the webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.1.5](https://github.com/silx-kit/vscode-h5web/compare/v0.1.4...v0.1.5)
+
+- ✨ **Allow opening HDF5 files of any size.** Previously, when you tried to
+  open a file larger than 2 GB, you would see an error in the H5Web webview
+  editor. Now, you will be able to browse for the file manually from inside the
+  webview, and doing so will bypass the file size limitation.
+
 ## [v0.1.4](https://github.com/silx-kit/vscode-h5web/compare/v0.1.3...v0.1.4)
 
 - ✨ Upgrade H5Web from v11.1.1 to v11.2.0

--- a/README.md
+++ b/README.md
@@ -57,5 +57,7 @@ available in
 This extension uses [h5wasm](https://github.com/usnistgov/h5wasm) to read HDF5
 files and therefore suffers from the following limitations:
 
-- Files bigger than 2GB cannot be read
-- External links cannot be resolved
+- Files bigger than 2GB cannot be opened automatically from the VS Code
+  Explorer. You will need to browse for them manually from the H5Web webview
+  editor when requested.
+- External links cannot be resolved.

--- a/app/App.tsx
+++ b/app/App.tsx
@@ -4,6 +4,11 @@ import Viewer from './Viewer';
 import { ErrorBoundary } from 'react-error-boundary';
 import { vscode } from './vscode-api';
 import { MessageType, type Message, type FileInfo } from '../src/models';
+import { H5WasmLocalFileProvider } from '@h5web/h5wasm';
+import StandaloneViewer from './StandaloneViewer';
+
+// 2 GB = 2 * 1024 * 1024 * 1024 B
+const MAX_SIZE_IN_BYTES = 2147483648;
 
 function App() {
   const [fileInfo, setFileInfo] = useState<FileInfo>();
@@ -21,6 +26,24 @@ function App() {
 
   if (!fileInfo) {
     return null;
+  }
+
+  if (fileInfo.size === 0) {
+    // e.g. when comparing git changes on an untracked file - https://github.com/silx-kit/vscode-h5web/issues/22
+    return <p>File does not exist</p>;
+  }
+
+  if (fileInfo.size >= MAX_SIZE_IN_BYTES) {
+    return (
+      <StandaloneViewer
+        customMessage={
+          <p>
+            File is too large to be opened from the explorer (max 2 GB). Please
+            browse for it from here:
+          </p>
+        }
+      />
+    );
   }
 
   return (

--- a/app/StandaloneViewer.tsx
+++ b/app/StandaloneViewer.tsx
@@ -1,0 +1,37 @@
+import { App } from '@h5web/app';
+import { H5WasmLocalFileProvider } from '@h5web/h5wasm';
+import { useState, type ReactNode } from 'react';
+import { getExportURL, getPlugin } from './utils';
+
+interface Props {
+  customMessage?: ReactNode;
+}
+
+function StandaloneViewer(props: Props) {
+  const { customMessage } = props;
+  const [fallbackFile, setFallbackFile] = useState<File>();
+
+  if (!fallbackFile) {
+    return (
+      <>
+        {customMessage}
+        <input
+          type="file"
+          onChange={(evt) => setFallbackFile(evt.target.files?.[0])}
+        />
+      </>
+    );
+  }
+
+  return (
+    <H5WasmLocalFileProvider
+      file={fallbackFile}
+      getExportURL={getExportURL}
+      getPlugin={getPlugin}
+    >
+      <App />
+    </H5WasmLocalFileProvider>
+  );
+}
+
+export default StandaloneViewer;

--- a/app/Viewer.tsx
+++ b/app/Viewer.tsx
@@ -4,26 +4,12 @@ import { suspend } from 'suspend-react';
 import { getExportURL, getPlugin } from './utils';
 import { type FileInfo } from '../src/models.js';
 
-// 2 GB = 2 * 1024 * 1024 * 1024 B
-const MAX_SIZE_IN_BYTES = 2147483648;
-
 interface Props {
   fileInfo: FileInfo;
 }
 
 function Viewer(props: Props) {
   const { fileInfo } = props;
-
-  if (fileInfo.size === 0) {
-    // e.g. when comparing git changes on an untracked file - https://github.com/silx-kit/vscode-h5web/issues/22
-    return <p>File does not exist</p>;
-  }
-
-  if (fileInfo.size >= MAX_SIZE_IN_BYTES) {
-    throw new Error(
-      'Cannot open: the file is bigger than the maximum supported size (2 GB)'
-    );
-  }
 
   const buffer = suspend(async () => {
     const res = await fetch(fileInfo.uri);

--- a/src/H5WebViewer.ts
+++ b/src/H5WebViewer.ts
@@ -124,7 +124,7 @@ export default class H5WebViewer
 				<meta charset="UTF-8">
 				<meta
           http-equiv="Content-Security-Policy"
-          content="default-src 'none'; connect-src ${cspSource} data:; script-src ${cspSource} 'unsafe-eval'; style-src ${cspSource}; img-src blob:;"
+          content="default-src 'none'; connect-src ${cspSource} data:; script-src ${cspSource} 'unsafe-eval'; style-src ${cspSource}; img-src blob:; worker-src blob:;"
         >
 				<meta name="viewport" content="width=device-width, initial-scale=1.0">
 				<title>H5Web</title>


### PR DESCRIPTION
So ... `<input type="file"`>` works inside webviews, duh!

![Peek 2024-04-19 13-54](https://github.com/silx-kit/vscode-h5web/assets/2936402/352252e5-b239-434e-b7c4-03fb1d6928b1)

It's not the ideal UX, but it's a workaround for now.

Now I'm wondering whether this UX is better than to try loading a 1.9 GB file into memory... But then where do you put the limit. I could add a command to open a "standalone" H5Web webview with a file picker like this but then discoverability would be a problem.

I think I'll wait to see what the performance are with a provider that can do range requests (cf. https://github.com/silx-kit/h5web/issues/1264), as this might give us a more generic solution.