### PR TITLE
Open JLD2 files in H5Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ following file extensions: `.h5`, `.hdf`, `.hdf5`, `.nx`
 `.cxi`
 ([Coherent X-ray Imaging](https://raw.githubusercontent.com/cxidb/CXI/master/cxi_file_format.pdf)),
 `.nc` ([netCDF4](https://docs.unidata.ucar.edu/nug/current/)), `.nc4`,
-[`.loom`](http://linnarssonlab.org/loompy/format/).
+[`.loom`](http://linnarssonlab.org/loompy/format/),
+[`jld2`](https://github.com/JuliaIO/JLD2.jl).
 
 To add more extensions, don't hesitate to
 [open an issue](https://github.com/silx-kit/vscode-h5web/issues/new) or

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "displayName": "H5Web",
         "selector": [
           {
-            "filenamePattern": "*.{h5,hdf,hdf5,nx,nxs,nx5,nexus,cxi,nc,nc4,loom}"
+            "filenamePattern": "*.{h5,hdf,hdf5,nx,nxs,nx5,nexus,cxi,nc,nc4,loom,jld2}"
           }
         ],
         "priority": "default"


### PR DESCRIPTION
Fix #46 

The previous PR #47 fixed support for committed datatypes, and this PR allows JLD2 files to open directly in H5Web.