### PR TITLE
Log warning when output file is too big to open

### DIFF
--- a/extension/H5WebViewer.ts
+++ b/extension/H5WebViewer.ts
@@ -8,6 +8,7 @@ import {
   type CustomDocument,
   type CustomReadonlyEditorProvider,
   type ExtensionContext,
+  type LogOutputChannel,
   Uri,
   type Webview,
   type WebviewPanel,
@@ -19,7 +20,10 @@ import { type Message, MessageType } from './models';
 import { PLUGINS } from './plugins';
 
 export default class H5WebViewer implements CustomReadonlyEditorProvider {
-  public constructor(private readonly context: ExtensionContext) {}
+  public constructor(
+    private readonly context: ExtensionContext,
+    private readonly outputChannel: LogOutputChannel,
+  ) {}
 
   public async openCustomDocument(uri: Uri): Promise<CustomDocument> {
     return { uri, dispose: () => {} };
@@ -88,7 +92,15 @@ export default class H5WebViewer implements CustomReadonlyEditorProvider {
 
           // Open output file in separate editor
           commands.executeCommand('workbench.action.keepEditor'); // if current editor is in preview mode, keep it open
-          window.showTextDocument(saveUri);
+
+          try {
+            await window.showTextDocument(saveUri);
+          } catch (error) {
+            this.outputChannel.warn(
+              'Unable to open file:',
+              error instanceof Error ? error.message : 'unknown error',
+            );
+          }
         }
       }
     });

--- a/extension/index.ts
+++ b/extension/index.ts
@@ -5,12 +5,18 @@ import H5WebViewer from './H5WebViewer';
 const EDITOR_IDS = ['h5web.viewer', 'h5web.fallback-viewer'];
 
 export function activate(context: ExtensionContext): void {
+  const outputChannel = window.createOutputChannel('H5Web', { log: true });
+
   context.subscriptions.push(
     ...EDITOR_IDS.map((id) =>
-      window.registerCustomEditorProvider(id, new H5WebViewer(context), {
-        webviewOptions: { retainContextWhenHidden: true },
-        supportsMultipleEditorsPerDocument: true,
-      }),
+      window.registerCustomEditorProvider(
+        id,
+        new H5WebViewer(context, outputChannel),
+        {
+          webviewOptions: { retainContextWhenHidden: true },
+          supportsMultipleEditorsPerDocument: true,
+        },
+      ),
     ),
   );
 }


### PR DESCRIPTION
Follows #53 

Turns out that if the export file is too big, `window.showTextDocument()` throws an error. To handle this more elegantly, I create a log output channel, pass it to the `H5WebViewer` class, and log a warning to it when the error occurs.

[Screencast from 2025-03-31 11-49-57.webm](https://github.com/user-attachments/assets/25f29925-f3f9-46b2-92b5-957862d4e0da)
