### PR TITLE
Don't let regenerating a file permanently kill the viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## dev
 
+- 🐛 Reload the file instead of getting stuck on an error when it is deleted and
+  recreated, or when it is still being written
+  [#76](https://github.com/silx-kit/vscode-h5web/issues/76)
+- 🐛 Release the previous contents of the file when reloading it, instead of
+  retaining a copy of every version that has been loaded
+  [#76](https://github.com/silx-kit/vscode-h5web/issues/76)
 - 🧩 Open `.nde` files in H5Web by default
 
 ## [v0.2.2](https://github.com/silx-kit/vscode-h5web/compare/v0.2.1...v0.2.2)

--- a/extension/H5WebViewer.ts
+++ b/extension/H5WebViewer.ts
@@ -18,6 +18,12 @@ import {
 import { type Message, MessageType } from './models';
 import { PLUGINS } from './plugins';
 
+// `watchFile` polls the file's stats, so it may well catch a file that is only
+// half-written, or that has been deleted but not recreated yet. Poll often, but
+// wait for the stats to stop changing before telling the viewer to reload.
+const WATCH_INTERVAL_IN_MS = 500;
+const SETTLE_DELAY_IN_MS = 1000;
+
 export default class H5WebViewer implements CustomReadonlyEditorProvider {
   public constructor(
     private readonly context: ExtensionContext,
@@ -51,23 +57,28 @@ export default class H5WebViewer implements CustomReadonlyEditorProvider {
 
     webview.onDidReceiveMessage(async (evt: Message) => {
       if (evt.type === MessageType.Ready) {
-        const uri = webview.asWebviewUri(document.uri).toString();
-        const name = basename(document.uri.fsPath);
         const { size } = await workspace.fs.stat(document.uri);
+        this.postFileInfo(webview, document, size);
 
-        webview.postMessage({
-          type: MessageType.FileInfo,
-          data: { uri, name, size },
-        });
+        // Report the size the file has once it has settled, rather than the size
+        // it had when the editor was opened. `watchFile` reports a size of 0
+        // when the file is missing, which the viewer knows how to handle.
+        let settleTimeout: ReturnType<typeof setTimeout> | undefined;
 
-        watchFile(document.uri.fsPath, () => {
-          webview.postMessage({
-            type: MessageType.FileInfo,
-            data: { uri, name, size },
-          });
-        });
+        watchFile(
+          document.uri.fsPath,
+          { interval: WATCH_INTERVAL_IN_MS },
+          (curr) => {
+            clearTimeout(settleTimeout);
+            settleTimeout = setTimeout(
+              () => this.postFileInfo(webview, document, curr.size),
+              SETTLE_DELAY_IN_MS,
+            );
+          },
+        );
 
         webviewPanel.onDidDispose(() => {
+          clearTimeout(settleTimeout);
           unwatchFile(document.uri.fsPath);
         });
 
@@ -102,6 +113,21 @@ export default class H5WebViewer implements CustomReadonlyEditorProvider {
           }
         }
       }
+    });
+  }
+
+  private postFileInfo(
+    webview: Webview,
+    document: CustomDocument,
+    size: number,
+  ): void {
+    webview.postMessage({
+      type: MessageType.FileInfo,
+      data: {
+        uri: webview.asWebviewUri(document.uri).toString(),
+        name: basename(document.uri.fsPath),
+        size,
+      },
     });
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,9 @@ function App() {
 
   return (
     <ErrorBoundary
+      // Retry when the file changes, so a failed load doesn't outlive the
+      // version of the file that failed to load
+      resetKeys={[fileInfo]}
       fallbackRender={({ error }) => (
         <p>{error instanceof Error ? error.message : 'Unknown error'}</p>
       )}

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -1,6 +1,7 @@
 import { App } from '@h5web/app';
 import { H5WasmBufferProvider } from '@h5web/h5wasm';
-import { suspend } from 'suspend-react';
+import { useEffect } from 'react';
+import { clear, suspend } from 'suspend-react';
 
 import { type FileInfo } from '../extension/models.js';
 import { getExportURL, getPlugin } from './utils';
@@ -14,8 +15,19 @@ function Viewer(props: Props) {
 
   const buffer = suspend(async () => {
     const res = await fetch(fileInfo.uri);
+
+    if (!res.ok) {
+      // Notably when the file has been deleted since it was last stat'd
+      throw new Error(`Unable to read file (${res.status} ${res.statusText})`);
+    }
+
     return res.arrayBuffer();
   }, [fileInfo]);
+
+  // `suspend` caches every buffer it has ever fetched, so release this one as
+  // soon as the file changes -- otherwise reloading retains a copy of every
+  // version of the file
+  useEffect(() => () => clear([fileInfo]), [fileInfo]);
 
   return (
     <H5WasmBufferProvider


### PR DESCRIPTION
`watchFile` fired mid-rewrite and `ErrorBoundary` lacked `resetKeys`. Fixes #76